### PR TITLE
Update goreleaser to latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dev-flow
 vendor/
 dist/
+
+# Vim swapfiles
+*.sw[po]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
   goarch:
   - amd64
   ldflags: []
+  main: ./main.go
 
 archive:
   name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"
@@ -36,7 +37,7 @@ brew:
     bin.install "dev-flow"
   test: |
     system "#{bin}/dev-flow", "-h"
-  
+
   github:
     owner: cyberark
     name: homebrew-tools
@@ -57,3 +58,4 @@ nfpm:
 
 release:
   disable: true
+  prerelease: auto

--- a/bin/build
+++ b/bin/build
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+BIN_NAME="dev-flow"
+GORELEASER_IMAGE="goreleaser/goreleaser:latest-cgo"
+
 GORELEASER_ARGS='--rm-dist --skip-validate'
 if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
   GORELEASER_ARGS="$GORELEASER_ARGS --snapshot"
@@ -7,15 +10,15 @@ fi
 
 git fetch --tags  # jenkins does not do this automatically yet
 
-docker-compose pull goreleaser
+docker pull "${GORELEASER_IMAGE}"
 
 echo "> Building and packaging binaries"
-docker-compose run --rm -T --entrypoint sh goreleaser -es <<EOF
-goreleaser release $GORELEASER_ARGS
-EOF
+docker run --rm -t \
+  -v "$PWD:/${BIN_NAME}" \
+  -w "/${BIN_NAME}" \
+  "${GORELEASER_IMAGE}" ${GORELEASER_ARGS}
 
-bin_name='dev-flow'
 goos='linux'  # uname -s | tr '[:upper:]' '[:lower:]'
 goarch="amd64"
 
-cp "dist/${goos}_${goarch}/${bin_name}" .  # for following test stages
+cp "dist/${goos}_${goarch}/${BIN_NAME}" .  # for following test stages

--- a/bin/test
+++ b/bin/test
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
-docker-compose run --rm -T --entrypoint sh goreleaser -es <<EOF
-go build -v
-./dev-flow -h
-EOF
+TEST_CMD='apk add --no-cache git build-base && go build && ./dev-flow -h'
+
+docker run --rm  -t \
+           -v "$PWD:/dev-flow" \
+           -w "/dev-flow" \
+           golang:1.11-alpine sh -c "${TEST_CMD}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,0 @@
-version: '3'
-services:
-  goreleaser:
-    image: cyberark/goreleaser
-    volumes:
-      - .:/dev-flow
-    working_dir: /dev-flow


### PR DESCRIPTION
We now use the latest goreleaser image and with this, we have removed
the need to use docker-compose at all and updated the goreleaser
specfile too.

Closes #55 