### PR TITLE
clean up label error handling

### DIFF
--- a/cmd/codereview.go
+++ b/cmd/codereview.go
@@ -40,8 +40,17 @@ var codereviewCmd = &cobra.Command{
 			log.Fatalln(err)
 		}
 
-		it.RemoveIssueLabel(issue, viper.GetString("labels.start"))
-		it.AddIssueLabel(issue, viper.GetString("labels.codereview"))
+		err = it.RemoveIssueLabel(issue, viper.GetString("labels.start"))
+
+		if err != nil {
+			log.Println(err)
+		}
+		
+		err = it.AddIssueLabel(issue, viper.GetString("labels.codereview"))
+
+		if err != nil {
+			log.Println(err)
+		}
 
 		scm := scm.GetClient()
 		pr := scm.GetPullRequest(branchName)

--- a/cmd/codereview.go
+++ b/cmd/codereview.go
@@ -40,21 +40,8 @@ var codereviewCmd = &cobra.Command{
 			log.Fatalln(err)
 		}
 
-		progressLabelName := viper.GetString("labels.start")
-
-		if progressLabelName != "" && issue.HasLabel(progressLabelName) {
-			it.RemoveIssueLabel(issue, progressLabelName)
-		}
-
-		reviewLabelName := viper.GetString("labels.codereview")
-
-		if reviewLabelName != "" {
-			err := it.AddIssueLabel(issue, reviewLabelName)
-
-			if err != nil {
-				log.Fatalln(err)
-			}
-		}
+		it.RemoveIssueLabel(issue, viper.GetString("labels.start"))
+		it.AddIssueLabel(issue, viper.GetString("labels.codereview"))
 
 		scm := scm.GetClient()
 		pr := scm.GetPullRequest(branchName)

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -76,8 +76,17 @@ var completeCmd = &cobra.Command{
 			)
 		}
 
-		it.RemoveIssueLabel(issue, viper.GetString("labels.codereview"))
-		it.AddIssueLabel(issue, viper.GetString("labels.complete"))
+		err = it.RemoveIssueLabel(issue, viper.GetString("labels.codereview"))
+
+		if err != nil {
+			log.Println(err)
+		}
+		
+		err = it.AddIssueLabel(issue, viper.GetString("labels.complete"))
+
+		if err != nil {
+			log.Println(err)
+		}
 
 		vc.CheckoutAndPull(pr.Base)
 

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -76,21 +76,8 @@ var completeCmd = &cobra.Command{
 			)
 		}
 
-		reviewLabelName := viper.GetString("labels.codereview")
-
-		if reviewLabelName != "" && issue.HasLabel(reviewLabelName) {
-			it.RemoveIssueLabel(issue, reviewLabelName)
-		}
-
-		completeLabelName := viper.GetString("labels.complete")
-
-		if completeLabelName != "" && !issue.HasLabel(completeLabelName) {
-			err := it.AddIssueLabel(issue, completeLabelName)
-
-			if err != nil {
-				log.Fatalln(err)
-			}
-		}
+		it.RemoveIssueLabel(issue, viper.GetString("labels.codereview"))
+		it.AddIssueLabel(issue, viper.GetString("labels.complete"))
 
 		vc.CheckoutAndPull(pr.Base)
 

--- a/cmd/label.go
+++ b/cmd/label.go
@@ -37,7 +37,11 @@ var labelCmd = &cobra.Command{
 			log.Fatalln(err)
 		}
 		
-		it.AddIssueLabel(issue, label)
+		err = it.AddIssueLabel(issue, label)
+
+		if err != nil {
+			log.Println(err)
+		}
 	},
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,7 +29,11 @@ var startCmd = &cobra.Command{
 		it.AssignIssue(issue, user)
 		fmt.Printf("Assigned issue %v to user %v.\n", *issue.Number, user)
 
-		it.AddIssueLabel(issue, viper.GetString("labels.start"))
+		err = it.AddIssueLabel(issue, viper.GetString("labels.start"))
+
+		if err != nil {
+			log.Println(err)
+		}
 
 		vc := versioncontrol.GetClient()
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,15 +29,7 @@ var startCmd = &cobra.Command{
 		it.AssignIssue(issue, user)
 		fmt.Printf("Assigned issue %v to user %v.\n", *issue.Number, user)
 
-		progressLabelName := viper.GetString("labels.start")
-
-		if progressLabelName != "" {
-			err := it.AddIssueLabel(issue, progressLabelName)
-
-			if err != nil {
-				log.Fatalln(err)
-			}
-		}
+		it.AddIssueLabel(issue, viper.GetString("labels.start"))
 
 		vc := versioncontrol.GetClient()
 

--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -156,13 +156,6 @@ func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 		return
 	}
 	
-	_, err := gh.getLabel(labelName)
-
-	if err != nil {
-		log.Printf("Unable to find label '%s'. Please make sure it exists.", labelName)
-		return
-	}
-
 	repo := versioncontrol.Git{}.Repo()
 	
 	_, err = gh.client().Issues.RemoveLabelForIssue(

--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -111,21 +111,19 @@ func (gh GitHub) AssignIssue(issue common.Issue, login string) {
 
 func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
 	if labelName == "" {
-		log.Println("Can not apply blank label.")
+		log.Println("Unable to apply blank label.")
 		return
 	}
 
 	if issue.HasLabel(labelName) {
-		msg := fmt.Sprintf("Issue %d already has label '%s'.", *issue.Number, labelName)
-		log.Println(msg)
+		log.Printf("Issue %d already has label '%s'.", *issue.Number, labelName)
 		return
 	}
 
 	_, err := gh.getLabel(labelName)
 
 	if err != nil {
-		msg := fmt.Sprintf("Unable to find label '%s'. Please make sure it exists.", labelName)
-		log.Println(msg)
+		log.Printf("Unable to find label '%s'. Please make sure it exists.", labelName)
 		return
 	}
 
@@ -140,34 +138,28 @@ func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
 		labels,
 	)
 
-	msg := ""
-
 	if err != nil {
-		msg = fmt.Sprintf("Failed to add label '%s' to issue %d.", labelName, *issue.Number)
+		log.Printf("Failed to add label '%s' to issue %d.", labelName, *issue.Number)
 	} else {
-		msg = fmt.Sprintf("Added label '%s' to issue %d.", labelName, *issue.Number)
+		log.Printf("Added label '%s' to issue %d.", labelName, *issue.Number)
 	}
-
-	log.Println(msg)
 }
 
 func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 	if labelName == "" {
-		log.Println("Can not apply blank label.")
+		log.Println("Unable to apply blank label.")
 		return
 	}
 
 	if !issue.HasLabel(labelName) {
-		msg := fmt.Sprintf("Issue %d does not have label '%s'.", *issue.Number, labelName)
-		log.Println(msg)
+		log.Printf("Issue %d does not have label '%s'.", *issue.Number, labelName)
 		return
 	}
 	
 	_, err := gh.getLabel(labelName)
 
 	if err != nil {
-		msg := fmt.Sprintf("Unable to find label '%s'. Please make sure it exists.", labelName)
-		log.Println(msg)
+		log.Printf("Unable to find label '%s'. Please make sure it exists.", labelName)
 		return
 	}
 
@@ -181,15 +173,11 @@ func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 		labelName,
 	)
 
-	msg := ""
-
 	if err != nil {
-		msg = fmt.Sprintf("Failed to remove label '%s' from issue %d.", labelName, *issue.Number)
+		log.Printf("Failed to remove label '%s' from issue %d.", labelName, *issue.Number)
 	} else {
-		msg = fmt.Sprintf("Removed label '%s' from issue %d.", labelName, *issue.Number)
+		log.Printf("Removed label '%s' from issue %d.", labelName, *issue.Number)
 	}
-
-	log.Println(msg)
 }
 
 func (gh GitHub) getLabel(name string) (*github.Label, error) {

--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -110,7 +110,7 @@ func (gh GitHub) AssignIssue(issue common.Issue, login string) {
 
 func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) error {
 	if labelName == "" {
-		return errors.New("Unable to apply blank label.")
+		return errors.New("Unable to add blank label.")
 	}
 
 	if issue.HasLabel(labelName) {
@@ -143,7 +143,7 @@ func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) error {
 
 func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) error {
 	if labelName == "" {
-		return errors.New("Unable to apply blank label.")
+		return errors.New("Unable to remove blank label.")
 	}
 
 	if !issue.HasLabel(labelName) {

--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/google/go-github/github"
@@ -109,22 +108,19 @@ func (gh GitHub) AssignIssue(issue common.Issue, login string) {
 	}
 }
 
-func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
+func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) error {
 	if labelName == "" {
-		log.Println("Unable to apply blank label.")
-		return
+		return errors.New("Unable to apply blank label.")
 	}
 
 	if issue.HasLabel(labelName) {
-		log.Printf("Issue %d already has label '%s'.", *issue.Number, labelName)
-		return
+		return fmt.Errorf("Issue %d already has label '%s'.", *issue.Number, labelName)
 	}
 
 	_, err := gh.getLabel(labelName)
 
 	if err != nil {
-		log.Printf("Unable to find label '%s'. Please make sure it exists.", labelName)
-		return
+		return err
 	}
 
 	repo := versioncontrol.Git{}.Repo()
@@ -139,26 +135,24 @@ func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
 	)
 
 	if err != nil {
-		log.Printf("Failed to add label '%s' to issue %d.", labelName, *issue.Number)
-	} else {
-		log.Printf("Added label '%s' to issue %d.", labelName, *issue.Number)
+		return fmt.Errorf("Failed to add label '%s' to issue %d: %s", labelName, *issue.Number, err)
 	}
+
+	return nil
 }
 
-func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
+func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) error {
 	if labelName == "" {
-		log.Println("Unable to apply blank label.")
-		return
+		return errors.New("Unable to apply blank label.")
 	}
 
 	if !issue.HasLabel(labelName) {
-		// No need for logging here, issue is already in desired state.
-		return
+		return fmt.Errorf("Issue %d does not have label '%s'.", *issue.Number, labelName)
 	}
 	
 	repo := versioncontrol.Git{}.Repo()
 	
-	_, err = gh.client().Issues.RemoveLabelForIssue(
+	_, err := gh.client().Issues.RemoveLabelForIssue(
 		context.Background(),
 		repo.Owner,
 		repo.Name,
@@ -167,10 +161,10 @@ func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 	)
 
 	if err != nil {
-		log.Printf("Failed to remove label '%s' from issue %d.", labelName, *issue.Number)
-	} else {
-		log.Printf("Removed label '%s' from issue %d.", labelName, *issue.Number)
+		return fmt.Errorf("Failed to remove label '%s' from issue %d: %s", labelName, *issue.Number, err)
 	}
+	
+	return nil
 }
 
 func (gh GitHub) getLabel(name string) (*github.Label, error) {

--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -111,7 +111,7 @@ func (gh GitHub) AssignIssue(issue common.Issue, login string) {
 
 func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
 	if labelName == "" {
-		log.Println("Invalid label:", labelName)
+		log.Println("Can not apply blank label.")
 		return
 	}
 
@@ -143,9 +143,9 @@ func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
 	msg := ""
 
 	if err != nil {
-		msg = fmt.Sprintf("Failed to add label '%s' to issue %d", labelName, *issue.Number)
+		msg = fmt.Sprintf("Failed to add label '%s' to issue %d.", labelName, *issue.Number)
 	} else {
-		msg = fmt.Sprintf("Added label '%s' to issue %d", labelName, *issue.Number)
+		msg = fmt.Sprintf("Added label '%s' to issue %d.", labelName, *issue.Number)
 	}
 
 	log.Println(msg)
@@ -153,7 +153,7 @@ func (gh GitHub) AddIssueLabel(issue common.Issue, labelName string) {
 
 func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 	if labelName == "" {
-		log.Println("Invalid label:", labelName)
+		log.Println("Can not apply blank label.")
 		return
 	}
 
@@ -184,9 +184,9 @@ func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 	msg := ""
 
 	if err != nil {
-		msg = fmt.Sprintf("Failed to remove label '%s' from issue %d", labelName, *issue.Number)
+		msg = fmt.Sprintf("Failed to remove label '%s' from issue %d.", labelName, *issue.Number)
 	} else {
-		msg = fmt.Sprintf("Removed label '%s' from issue %d", labelName, *issue.Number)
+		msg = fmt.Sprintf("Removed label '%s' from issue %d.", labelName, *issue.Number)
 	}
 
 	log.Println(msg)

--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -152,7 +152,7 @@ func (gh GitHub) RemoveIssueLabel(issue common.Issue, labelName string) {
 	}
 
 	if !issue.HasLabel(labelName) {
-		log.Printf("Issue %d does not have label '%s'.", *issue.Number, labelName)
+		// No need for logging here, issue is already in desired state.
 		return
 	}
 	

--- a/issuetracking/issuetracking.go
+++ b/issuetracking/issuetracking.go
@@ -12,7 +12,7 @@ type IssueTrackingClient interface {
 	Issues() []common.Issue
 	Issue(string) (common.Issue, error)
 	AssignIssue(common.Issue, string)
-	AddIssueLabel(common.Issue, string) error
+	AddIssueLabel(common.Issue, string)
 	RemoveIssueLabel(common.Issue, string)
 }
 

--- a/issuetracking/issuetracking.go
+++ b/issuetracking/issuetracking.go
@@ -12,8 +12,8 @@ type IssueTrackingClient interface {
 	Issues() []common.Issue
 	Issue(string) (common.Issue, error)
 	AssignIssue(common.Issue, string)
-	AddIssueLabel(common.Issue, string)
-	RemoveIssueLabel(common.Issue, string)
+	AddIssueLabel(common.Issue, string) error
+	RemoveIssueLabel(common.Issue, string) error
 }
 
 func GetClient() IssueTrackingClient {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,14 @@
 package main
 
-import "github.com/cyberark/dev-flow/cmd"
+import (
+	"log"
+	
+	"github.com/cyberark/dev-flow/cmd"
+)
 
 func main() {
+	log.SetPrefix("LOG: ")
+	log.SetFlags(log.Llongfile)
+	
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	log.SetPrefix("LOG: ")
+	log.SetPrefix("INFO: ")
 	log.SetFlags(log.Llongfile)
 	
 	cmd.Execute()


### PR DESCRIPTION
close #9

This PR Makes it so that failure to add / remove a label is logged instead of becoming a show-stopper.