### PR TITLE
Rework GitHub service wrapper

### DIFF
--- a/issuetracking/github.go
+++ b/issuetracking/github.go
@@ -8,14 +8,14 @@ import (
 	"github.com/google/go-github/github"
 
 	"github.com/cyberark/dev-flow/common"
-	"github.com/cyberark/dev-flow/services"
+	"github.com/cyberark/dev-flow/service"
 	"github.com/cyberark/dev-flow/versioncontrol"
 )
 
 type GitHub struct{}
 
-func newGitHubClient() services.GitHub {
-	return services.GitHub{}.GetClient()
+func newGitHubClient() service.GitHub {
+	return service.GitHub{}.GetClient()
 }
 
 func toCommonIssue(ghIssue *github.Issue) common.Issue {

--- a/scm/github.go
+++ b/scm/github.go
@@ -6,14 +6,14 @@ import (
 	"github.com/google/go-github/github"
 
 	"github.com/cyberark/dev-flow/common"
-	"github.com/cyberark/dev-flow/services"
+	"github.com/cyberark/dev-flow/service"
 	"github.com/cyberark/dev-flow/versioncontrol"
 )
 
 type GitHub struct{}
 
-func newGitHubClient() services.GitHub {
-	return services.GitHub{}.GetClient()
+func newGitHubClient() service.GitHub {
+	return service.GitHub{}.GetClient()
 }
 
 func (gh GitHub) GetPullRequest(branchName string) *PullRequest {

--- a/service/github.go
+++ b/service/github.go
@@ -1,4 +1,4 @@
-package services
+package service
 
 import (
 	"context"

--- a/service/github.go
+++ b/service/github.go
@@ -39,14 +39,14 @@ func (gh GitHub) GetClient() GitHub {
 	return GitHub{}
 }
 
-func (gh GitHub) GetUser(username string) (*github.User, error) {
-	ghUser, _, err := newClient().Users.Get(context.Background(), username)
+func (gh GitHub) GetUser(login string) (*github.User, error) {
+	user, _, err := newClient().Users.Get(context.Background(), login)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return ghUser, nil
+	return user, nil
 }
 
 func (gh GitHub) GetIssues(repo versioncontrol.Repo) ([]*github.Issue, error) {

--- a/services/github.go
+++ b/services/github.go
@@ -2,19 +2,31 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"golang.org/x/oauth2"
 
 	"github.com/google/go-github/github"
 
-	"github.com/cyberark/dev-flow/common"
+	"github.com/cyberark/dev-flow/versioncontrol"
 )
+
+type GitHubClient interface {
+	GetUser(string) (*github.User, error)
+	GetIssues(versioncontrol.Repo) ([]*github.Issue, error)
+	GetIssue(repo versioncontrol.Repo, issueNum int) (*github.Issue, error)
+	AssignIssue(repo versioncontrol.Repo, issueNum int, assigneeLogin string) (error)
+	GetLabel(repo versioncontrol.Repo, name string) (*github.Label, error)
+	AddLabelToIssue(repo versioncontrol.Repo, issueNum int, labelName string) (error)
+	RemoveLabelForIssue(repo versioncontrol.Repo, issueNum int, labelName string) (error)
+	GetPullRequests(repo versioncontrol.Repo, branchName string) ([]*github.PullRequest, error)
+	GetPullRequest(repo versioncontrol.Repo, pullRequestNum int) (*github.PullRequest, error)
+}
 
 type GitHub struct{}
 
-func (gh GitHub) GetClient() *github.Client {
-
+func newClient() *github.Client {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN")},
 	)
@@ -23,25 +35,201 @@ func (gh GitHub) GetClient() *github.Client {
 	return github.NewClient(tc)
 }
 
-func (gh GitHub) ToCommonIssue(ghIssue *github.Issue) common.Issue {
-	var assignee *string
+func (gh GitHub) GetClient() GitHub {
+	return GitHub{}
+}
 
-	if ghIssue.Assignee != nil {
-		assignee = ghIssue.Assignee.Login
+func (gh GitHub) GetUser(username string) (*github.User, error) {
+	ghUser, _, err := newClient().Users.Get(context.Background(), username)
+
+	if err != nil {
+		return nil, err
 	}
 
-	ghLabels := ghIssue.Labels
-	labels := make([]string, len(ghLabels))
+	return ghUser, nil
+}
 
-	for i, ghLabel := range ghLabels {
-		labels[i] = *ghLabel.Name
+func (gh GitHub) GetIssues(repo versioncontrol.Repo) ([]*github.Issue, error) {
+	issues, _, err := newClient().Issues.ListByRepo(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		nil,
+	)
+
+	if err != nil {
+		return nil, err
 	}
 
-	return common.Issue{
-		URL:      ghIssue.HTMLURL,
-		Number:   ghIssue.Number,
-		Title:    ghIssue.Title,
-		Assignee: assignee,
-		Labels:   labels,
+	return issues, nil
+}
+
+func (gh GitHub) GetIssue(repo versioncontrol.Repo, issueNum int) (*github.Issue, error) {
+	issue, _, err := newClient().Issues.Get(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		issueNum,
+	)
+
+	if err != nil {
+		return nil, err
 	}
+
+	return issue, nil
+}
+
+func (gh GitHub) AssignIssue(repo versioncontrol.Repo, issueNum int, assigneeLogin string) (error) {
+	_, _, err := newClient().Issues.AddAssignees(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		issueNum,
+		[]string{assigneeLogin},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gh GitHub) GetLabel(repo versioncontrol.Repo, name string) (*github.Label, error) {
+	label, _, err := newClient().Issues.GetLabel(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		name,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return label, nil
+}
+
+func (gh GitHub) AddLabelToIssue(repo versioncontrol.Repo, issueNum int, labelName string) (error) {
+	_, _, err := newClient().Issues.AddLabelsToIssue(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		issueNum,
+		[]string{labelName},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gh GitHub) RemoveLabelForIssue(repo versioncontrol.Repo, issueNum int, labelName string) (error) {
+	_, err := newClient().Issues.RemoveLabelForIssue(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		issueNum,
+		labelName,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gh GitHub) GetPullRequests(repo versioncontrol.Repo, branchName string) ([]*github.PullRequest, error) {
+	opts := &github.PullRequestListOptions{
+		State: "open",
+		Base:  "master",
+		Head:  fmt.Sprintf("%v:%v", repo.Owner, branchName),
+	}
+
+	pullRequests, _, err := newClient().PullRequests.List(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		opts,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pullRequests, nil
+}
+
+func (gh GitHub) GetPullRequest(repo versioncontrol.Repo, pullRequestNum int) (*github.PullRequest, error) {
+	pullRequest, _, err := newClient().PullRequests.Get(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		pullRequestNum,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pullRequest, nil
+}
+
+func (gh GitHub) CreatePullRequest(repo versioncontrol.Repo, newPullRequest *github.NewPullRequest) (*github.PullRequest, error) {
+	pullRequest, _, err := newClient().PullRequests.Create(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		newPullRequest,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pullRequest, nil
+}
+
+func (gh GitHub) RequestReviewer(repo versioncontrol.Repo, pullRequestNum int, reviewerLogin string) (error) {
+	reviewersRequest := github.ReviewersRequest{
+		Reviewers: []string{reviewerLogin},
+	}
+	
+	_, _, err := newClient().PullRequests.RequestReviewers(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		pullRequestNum,
+		reviewersRequest,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gh GitHub) MergePullRequest(repo versioncontrol.Repo, pullRequestNum int, mergeMethod string) (bool, error) {
+	pullRequestOptions := &github.PullRequestOptions{
+		MergeMethod: mergeMethod,
+	}
+
+	mergeResult, _, err := newClient().PullRequests.Merge(
+		context.Background(),
+		repo.Owner,
+		repo.Name,
+		pullRequestNum,
+		"",
+		pullRequestOptions,
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	return *mergeResult.Merged, nil
 }


### PR DESCRIPTION
This PR reworks the github service wrapper to do most of the heavy lifting with GitHub, acting as a thin wrapper around its API endpoints. This is a step towards being able to stub the service when testing by swapping in a service client that doesn't make remote calls.